### PR TITLE
Add support for other media types (XML, etc.)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,33 +1,38 @@
-const findJsonMimeType = (header) => {
+const isVendorContentType = (header) => {
     if (header.name === undefined) {
         return false;
     }
     return (
         header.name.toLowerCase() === 'content-type' &&
-        header.value.includes('json')
+        header.value.startsWith('application/vnd.') &&
+        header.value.includes('+')
     );
 };
 
-const overrideJsonHeader = (request) =>
+// Checks if the response has a vendor 'Content-Type' header and removes the "vendor part".
+// E.g. "application/vnd.custom+xml" becomes "application/xml" and
+// "application/vnd.smth+json" is changed to "application/json".
+const overrideVendorContentType = (request) =>
     new Promise((resolve) => {
-        if (request.responseHeaders.find(findJsonMimeType)) {
-            const jsonHeader = {
+        const vendorCTH = request.responseHeaders.find(isVendorContentType);
+        if (vendorCTH) {
+            const genericCTH = {
                 name: 'Content-Type',
-                value: 'application/json',
+                value: 'application/' + vendorCTH.value.substring(vendorCTH.value.indexOf('+') + 1),
             };
-            request.responseHeaders.push(jsonHeader);
+            request.responseHeaders.push(genericCTH);
         }
 
         resolve({ responseHeaders: request.responseHeaders });
     });
 
 browser.webRequest.onHeadersReceived.addListener(
-    overrideJsonHeader,
+    overrideVendorContentType,
     {
         urls: ['<all_urls>'],
     },
     ['blocking', 'responseHeaders'],
 );
 
-exports.findJsonMimeType = findJsonMimeType;
-exports.overrideJsonHeader = overrideJsonHeader;
+exports.isVendorContentType = isVendorContentType;
+exports.overrideVendorContentType = overrideVendorContentType;


### PR DESCRIPTION
The code has been made more generic to support any vendor Content-Type's.

In addition to the original JSON support (e.g. `application/vnd.spring-boot.actuator.v1+json`) the add-on would now handle also XML (e.g. `application/vnd.custom+xml`) and other media types.

Non-vendor Content-Type's like `application/atom+xml` are left intact.